### PR TITLE
LTX DiT: run the value product as an NT product (opt-in), ~1400x closer to an f64 reference

### DIFF
--- a/crates/cortiq-engine/src/ltxdit.rs
+++ b/crates/cortiq-engine/src/ltxdit.rs
@@ -623,13 +623,45 @@ impl Attn {
         let mut vh = vec![0f32; m * dh];
         let mut sc = vec![0f32; n * m];
         let mut oh = vec![0f32; n * dh];
+        // PV and QK cost the same flops, and PV takes twice the clock:
+        // measured on this stand at 512x512x49, per denoise step, scores
+        // 6.03 s against values 12.13 s (three steps, 6.03-6.54 and
+        // 12.13-12.71). The reason is which cooperative kernel each lands
+        // on -- `gemm_nt` picks `gemm_nt_coop`, whose right operand is read
+        // along rows, while `gemm_dx` picks `gemm_nn_coop` and reads v down
+        // columns of its [tokens, dh] block. Both are on the matrix units;
+        // the difference is the access pattern, not the acceleration.
+        //
+        // The image DiT already solved exactly this (`gpu_wgpu.rs:23664`:
+        // "transpose it once per block and PV becomes the NT product QK
+        // already is", 4.76 -> 2.91 s a step, frames within 0.1%). Here the
+        // transpose is free: v is gathered per head anyway, so gathering it
+        // as [dh, tokens] is the same count of writes to different offsets.
+        //
+        // OFF by default until measured on THIS path. The image DiT's
+        // number is its own; quoting it as the expected win here would be
+        // the same mistake as taking a benchmark out of a docstring.
+        // `CMF_LTX_PV_NT=1` turns it on.
+        let pv_nt = std::env::var("CMF_LTX_PV_NT").as_deref() == Ok("1");
         for h in 0..self.heads {
             for i in 0..n {
                 qh[i * dh..(i + 1) * dh].copy_from_slice(&q[i * inner + h * dh..][..dh]);
             }
             for j in 0..m {
                 kh[j * dh..(j + 1) * dh].copy_from_slice(&k[j * inner + h * dh..][..dh]);
-                vh[j * dh..(j + 1) * dh].copy_from_slice(&v[j * inner + h * dh..][..dh]);
+            }
+            if pv_nt {
+                // vh holds vᵀ: [dh, tokens], so PV is an NT product.
+                for j in 0..m {
+                    let src = &v[j * inner + h * dh..][..dh];
+                    for (d, s) in src.iter().enumerate() {
+                        vh[d * m + j] = *s;
+                    }
+                }
+            } else {
+                for j in 0..m {
+                    vh[j * dh..(j + 1) * dh].copy_from_slice(&v[j * inner + h * dh..][..dh]);
+                }
             }
             if prof {
                 t = attn_prof::add(&attn_prof::GATHER, t);
@@ -652,7 +684,13 @@ impl Attn {
                 t = attn_prof::add(&attn_prof::SOFT, t);
             }
             oh.iter_mut().for_each(|x| *x = 0.0);
-            crate::fcd_ops::gemm_dx(&sc, &vh, &mut oh, n, dh, m, pool);
+            if pv_nt {
+                // oh[n, dh] = sc[n, m] · (vᵀ[dh, m])ᵀ  -- gemm_nt's (n, k, m)
+                // is (tokens_out, reduction, width), so k = m and m = dh here.
+                crate::fcd_ops::gemm_nt(&sc, &vh, &mut oh, n, m, dh, pool);
+            } else {
+                crate::fcd_ops::gemm_dx(&sc, &vh, &mut oh, n, dh, m, pool);
+            }
             if prof {
                 t = attn_prof::add(&attn_prof::VALUE, t);
             }

--- a/crates/cortiq-engine/tests/pv_nt_parity.rs
+++ b/crates/cortiq-engine/tests/pv_nt_parity.rs
@@ -1,0 +1,148 @@
+//! Is PV-as-NT the same product as PV-as-NN, and which one is right?
+//!
+//! A render cannot answer this. The A/B on the real pipeline showed the patched
+//! arm differing from the unpatched one by relative L2 0.070 -- and cortiq's own
+//! gpu lane differs from its own cpu lane, with no patch at all, by 0.086. A
+//! diffusion latent amplifies any perturbation, so a deviation the size of the
+//! engine's existing spread proves nothing in either direction.
+//!
+//! So: fixed inputs, both arms, and an f64 reference computed here. The f64 arm
+//! is what makes this decisive -- without it the test can only say the two
+//! disagree, not which one is wrong.
+//!
+//!     cargo test --release -p cortiq-engine --test pv_nt_parity -- --nocapture
+//!     set CMF_GPU=wgpu & set CMF_GPU_ADAPTER=1 & cargo test --release ...
+//!
+//! Run it BOTH ways. Without CMF_GPU the host kernels are exercised; with it the
+//! device arms are. The bug hunted here was hypothesised to live in one and not
+//! the other, and a single run cannot tell those apart.
+
+use cortiq_engine::fcd_ops::{gemm_dx, gemm_nt};
+
+fn lcg(seed: &mut u64) -> f32 {
+    *seed = seed.wrapping_mul(6364136223846793005).wrapping_add(1);
+    ((*seed >> 40) as f32 / (1u32 << 24) as f32) - 0.5
+}
+
+/// O = P·V in f64, row-major, the answer both arms are trying to produce.
+fn reference(p: &[f32], v: &[f32], n: usize, m: usize, dh: usize) -> Vec<f64> {
+    let mut o = vec![0f64; n * dh];
+    for i in 0..n {
+        for j in 0..m {
+            let pij = p[i * m + j] as f64;
+            if pij == 0.0 {
+                continue;
+            }
+            for d in 0..dh {
+                o[i * dh + d] += pij * v[j * dh + d] as f64;
+            }
+        }
+    }
+    o
+}
+
+fn rel_l2(got: &[f32], want: &[f64]) -> f64 {
+    let mut num = 0f64;
+    let mut den = 0f64;
+    for (g, w) in got.iter().zip(want) {
+        let d = *g as f64 - *w;
+        num += d * d;
+        den += w * w;
+    }
+    (num / den.max(f64::MIN_POSITIVE)).sqrt()
+}
+
+#[test]
+fn pv_nt_matches_pv_nn_and_the_f64_reference() {
+    // The shapes a real 512x512x49 LTX render actually asks for. `m` is the
+    // token count of the thing being attended to, and 49 is the audio one --
+    // the case where the two arms take different branches, because 49 % 4 != 0
+    // fails the cooperative filter on both but the fallbacks differ.
+    let cases: [(usize, usize, usize, &str); 4] = [
+        (1792, 1792, 128, "self-attn video"),
+        (1792, 1024, 128, "cross-attn to context"),
+        (1792, 49, 128, "video attending audio (m=49, not %4)"),
+        (49, 1792, 128, "audio attending video (n=49)"),
+    ];
+
+    let gpu = std::env::var("CMF_GPU").is_ok() && cortiq_engine::gpu::enabled_here();
+    eprintln!("device lane: {}", if gpu { "ON (CMF_GPU set, backend up)" } else { "off -- host kernels only" });
+    eprintln!();
+    eprintln!("{:<38} {:>12} {:>12} {:>12}", "case", "NN vs f64", "NT vs f64", "NN vs NT");
+
+    let mut bad = Vec::new();
+    for (n, m, dh, name) in cases {
+        let mut seed = 0xdead_beef_1234_5678u64;
+        // P is a softmax output in the real thing: non-negative, rows sum to 1.
+        // Feeding signed noise would hide a sign or transpose error behind
+        // cancellation, so build a real row-stochastic matrix.
+        let mut p = vec![0f32; n * m];
+        for row in p.chunks_exact_mut(m) {
+            let mut s = 0f32;
+            for x in row.iter_mut() {
+                *x = lcg(&mut seed) + 0.5 + 1e-3;
+                s += *x;
+            }
+            for x in row.iter_mut() {
+                *x /= s;
+            }
+        }
+        let v: Vec<f32> = (0..m * dh).map(|_| lcg(&mut seed)).collect();
+
+        // Arm A: what the engine does today.
+        let mut o_nn = vec![0f32; n * dh];
+        gemm_dx(&p, &v, &mut o_nn, n, dh, m, None);
+
+        // Arm B: v gathered as [dh, tokens], PV as an NT product.
+        let mut vt = vec![0f32; dh * m];
+        for j in 0..m {
+            for d in 0..dh {
+                vt[d * m + j] = v[j * dh + d];
+            }
+        }
+        let mut o_nt = vec![0f32; n * dh];
+        gemm_nt(&p, &vt, &mut o_nt, n, m, dh, None);
+
+        let want = reference(&p, &v, n, m, dh);
+        let e_nn = rel_l2(&o_nn, &want);
+        let e_nt = rel_l2(&o_nt, &want);
+        let want_nn: Vec<f64> = o_nn.iter().map(|&x| x as f64).collect();
+        let e_ab = rel_l2(&o_nt, &want_nn);
+
+        eprintln!("{name:<38} {e_nn:12.3e} {e_nt:12.3e} {e_ab:12.3e}");
+
+        // WHAT IS ASSERTED, and why not an absolute tolerance.
+        //
+        // The first version asserted both arms within 1e-4 of f64 and failed --
+        // on the EXISTING arm, in three of four shapes. Measured on the device
+        // lane: NN sits at 2.6e-4 to 2.9e-4 while NT reaches 1.5e-7 to 2.1e-7,
+        // the f32 floor. So an absolute bar either fails code this test was not
+        // written to judge, or has to be loosened until it stops meaning
+        // anything.
+        //
+        // The invariant that matters for the change under test is comparative:
+        // the NT arm must be NO WORSE than the arm it would replace. A little
+        // slack (2x) keeps a shape where both are already at the f32 floor from
+        // failing on which one happens to round better.
+        if e_nt > e_nn.max(1e-7) * 2.0 {
+            bad.push(format!(
+                "{name}: NT is {e_nt:.3e} off f64 against NN's {e_nn:.3e} -- the \
+                 replacement is LESS accurate than what it replaces"
+            ));
+        }
+        // Not a failure, but the reason this file exists twice over: report it.
+        if e_nn > e_nt * 10.0 {
+            eprintln!(
+                "  note: {name}: the existing NN arm is {:.0}x further from f64 than NT",
+                e_nn / e_nt.max(f64::MIN_POSITIVE)
+            );
+        }
+    }
+
+    eprintln!();
+    eprintln!("NOT covered: the device lane unless CMF_GPU was set for this run,");
+    eprintln!("and any shape not in the list above. A pass here is about PV only --");
+    eprintln!("it says nothing about the gather that feeds it in ltxdit.rs.");
+
+    assert!(bad.is_empty(), "\n{}", bad.join("\n"));
+}


### PR DESCRIPTION
## What

`ltxdit.rs` computes the value product with `fcd_ops::gemm_dx`, which lands on `gemm_nn_coop`, whose right operand is read **down columns** of v's `[tokens, dh]` block. QK uses `gemm_nt` → `gemm_nt_coop` and reads along rows. Both are on the matrix units; the difference is the access pattern.

`v` is already gathered per head, so gathering it as `[dh, tokens]` is the same count of writes to different offsets, and PV becomes the NT product QK already is. No transpose pass is added.

This is the same fix the image DiT already applies at `gpu_wgpu.rs:23664` ("transpose it once per block and PV becomes the NT product QK already is"), brought to the LTX path.

Behind `CMF_LTX_PV_NT=1`, **off by default** — see *What I did not establish*.

## Accuracy (the actual reason for this PR)

`crates/cortiq-engine/tests/pv_nt_parity.rs` computes PV on fixed inputs against an **f64 reference calculated in the test**, in the four shapes a real render asks for. P is built as a genuine row-stochastic matrix so a sign or transpose error cannot hide behind cancellation.

RTX 3090, `CMF_GPU=wgpu CMF_GPU_ADAPTER=1`, release build of `8bd8e14`. Relative L2 against the f64 reference:

| shape (n × m × dh) | `gemm_dx` (NN) | `gemm_nt` (NT) | ratio |
|---|---|---|---|
| 1792 × 1792 × 128 — self-attn | 2.836e-4 | **2.017e-7** | **1406×** |
| 1792 × 1024 × 128 — cross-attn | 2.623e-4 | **1.530e-7** | **1714×** |
| 1792 × 49 × 128 — video attending audio | 1.307e-7 | 7.149e-8 | 1.8× |
| 49 × 1792 × 128 — audio attending video | 2.894e-4 | **2.050e-7** | **1412×** |

The NT arm reaches the f32 floor in all four. The existing arm is three orders above it in three of four.

On the host lane the same holds, with one difference worth knowing: for the self-attn shape both arms return **bit-identical** results and both sit at 2.836e-4. So this is not a device-vs-host issue — it is the NN product itself.

The test asserts a comparative invariant (NT no worse than NN), not an absolute tolerance. An absolute bar fails the *existing* code, which is not what this test is for.

## Speed

512×512, 49 frames, 3 steps, seed 1234, RTX 3090, four interleaved runs (off/on/off/on), stable steps only:

| | `values` per step | `gather` per step |
|---|---|---|
| off | 11.90 – 15.33 s | 1.48 – 1.81 s |
| on | **5.10 – 5.38 s** | 3.42 – 3.58 s |

No overlap on `values`. The transposed gather costs ~1.9 s.

## What I did not establish

- **A step-level speedup.** The off arm alone spread 56.1–66.5 s per step on my stand; that swamps the ~5.6 s the sub-phases predict. Do not quote a step win from this.
- **That the default should flip.** The accuracy case looks strong to me, but it is your tree and your call, so this ships opt-in.
- **Anything on non-NVIDIA or non-Windows hardware.** One machine, one driver.

## A note on how this was found

I first "confirmed" the patch was broken, using max element-wise relative error on the latent with a 1e-6 clamp. That criterion also reports your **gpu lane vs your cpu lane, with no patch at all**, as a different answer (6.7e2). A diffusion latent amplifies any perturbation, so a render cannot separate a rounding change from a bug — hence the fixed-input f64 test rather than a visual or latent comparison.

Happy to split, rework, or drop this.

Four unrelated observations from the same session are filed separately rather than bundled here — #2 (a benchmark figure in a docstring that does not reproduce), #3 (GPU tests reporting `ok` while skipping), #4 (`vk_coop` failing deterministically, on a lane nothing in production calls), #5 (a stale comment about the cooperative default). None of them block this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

